### PR TITLE
fix(snippets): update artillery links to working ones

### DIFF
--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -4,7 +4,7 @@
 		"body": [
 			"function myFunction(context, ee, next) {",
 			"\t//Change your function name and add your logic here.",
-			"\t//For more information, check: https://artillery.io/docs/http-reference/#function-signatures",
+			"\t//For more information, check: https://docs.art/http-reference#function-signatures",
 			"\tnext();",
 			"};"
 		],
@@ -15,7 +15,7 @@
 		"body": [
 			"function myBeforeRequestHandler(req, context, ee, next) {",
 			"\t//Change your function name and add your logic here.",
-			"\t//For more information, check: https://artillery.io/docs/http-reference/#function-signatures",
+			"\t//For more information, check: https://docs.art/http-reference#function-signatures",
 			"\tnext();",
 			"};"
 		],
@@ -26,7 +26,7 @@
 		"body": [
 			"function myBeforeScenarioHandler(context, ee, next) {",
 			"\t//Change your function name and add your logic here.",
-			"\t//For more information, check: https://artillery.io/docs/http-reference/#function-signatures",
+			"\t//For more information, check: https://docs.art/http-reference#function-signatures",
 			"\tnext();",
 			"};"
 		],
@@ -37,7 +37,7 @@
 		"body": [
 			"function myAfterResponseHandler(req, res, context, ee, next) {",
 			"\t//Change your function name and add your logic here.",
-			"\t//For more information, check: https://artillery.io/docs/http-reference/#function-signatures",
+			"\t//For more information, check: https://docs.art/http-reference#function-signatures",
 			"\tnext();",
 			"};"
 		],
@@ -48,7 +48,7 @@
 		"body": [
 			"function myAfterScenarioHandler(context, ee, next) {",
 			"\t//Change your function name and add your logic here.",
-			"\t//For more information, check: https://artillery.io/docs/http-reference/#function-signatures",
+			"\t//For more information, check: https://docs.art/http-reference#function-signatures",
 			"\tnext();",
 			"};"
 		],

--- a/snippets/yaml.json
+++ b/snippets/yaml.json
@@ -9,7 +9,7 @@
 			"\t\t\tarrivalRate: 1",
 			"\t\t\tname: \"Phase 1\"",
 			"\tprocessor: \"./myProcessor.js\"",
-			"# For more information: https://artillery.io/docs/script-reference/"
+			"# For more information: https://docs.art/reference/test-script#config-section"
 		],
 		"description": "Basic Artillery Config"
 	},
@@ -20,7 +20,7 @@
 			"\t- flow:",
 			"\t\t\t- get:",
 			"\t\t\t\t\turl: \"/\"",
-			"# For more information: https://artillery.io/docs/script-reference/"
+			"# For more information: https://docs.art/reference/test-script#scenarios-section"
 		],
 		"description": "Basic Artillery Scenario"
 	},
@@ -38,7 +38,7 @@
 			"\t\t\t\t\tafterResponse: [\"myAfterResponseHandler\"]",
 			"\t\t\t- function: [\"myFunction\"]",
 			"\t\tafterScenario: [\"afterScenarioHandler\"]",
-			"# For more information: https://artillery.io/docs/script-reference/"
+			"# For more information: https://docs.art/reference/test-script#scenarios-section"
 		],
 		"description": "Artillery Scenario With Hooks"
 	}


### PR DESCRIPTION
## Why

All of these links were broken. We now use `docs.art` which redirects, so even if these links change in the future, hopefully the redirections will be kept in place.